### PR TITLE
Add sd_product tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -9,6 +9,8 @@
   {% include "edicy-tools-variables" with "product_page" %}
   {% include "html-head" %}
   {% include "edicy-tools-styles" %}
+  
+  {% sd_product %}
 </head>
 
 <body class="item-page product-page content-page{% unless editmode or site_header_has_content %} empty-site-header{% endunless %} js-bg-picker-area{% if fallback_state %} bgpicker-fallback{% endif %}">


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #175 